### PR TITLE
postView 내용 부분 태그 삭제

### DIFF
--- a/src/components/ReadPage/PostView.js
+++ b/src/components/ReadPage/PostView.js
@@ -16,6 +16,7 @@ const PostView = () => {
   const { post_id } = useParams();
   const dispatch = useDispatch();
   const [postContents, setPostContents] = useState([]);
+  const [postIntroduce, setPostIntroduce] = useState();
   const [userImg, setUserImg] = useState(
     "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png"
   );
@@ -29,6 +30,7 @@ const PostView = () => {
     })
       .then(response => {
         setPostContents(response.data.data);
+        setPostIntroduce(response.data.data.content);
         if (response.data.data.poster_profile) {
           setUserImg(
             `data:image/jpeg;base64,${response.data.data.poster_profile.image_data}`
@@ -98,7 +100,9 @@ const PostView = () => {
       <div className="postContentWrapper">
         <h2 className="postInfo">프로젝트 소개</h2>
         <hr></hr>
-        <div className="postContent">{postContents.content}</div>
+        <div className="postContent">
+          {postIntroduce.replace(/(<([^>]+)>)/gi, "")}
+        </div>
         <PostComment comment={postContents} />
         <Footer />
       </div>

--- a/src/components/ReadPage/PostView.js
+++ b/src/components/ReadPage/PostView.js
@@ -101,7 +101,7 @@ const PostView = () => {
         <h2 className="postInfo">프로젝트 소개</h2>
         <hr></hr>
         <div className="postContent">
-          {postIntroduce.replace(/(<([^>]+)>)/gi, "")}
+          {postIntroduce?.replace(/(<([^>]+)>)/gi, "")}
         </div>
         <PostComment comment={postContents} />
         <Footer />

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,14 @@
+import React from "react";
+CKEDITOR.editorConfig = function (config) {
+  config.toolbar = [{ name: "tools", items: ["Maximize", "Source"] }];
+
+  //config.removeButtons = 'CodeSnippet,NewPage,Save,Preview,Print,Templates,Bold,RemoveFormat,Italic,Underline,Strike,Subscript,Superscript,NumberedList,BulletedList,Indent,Outdent,Blockquote,CreateDiv,BidiLtr,BidiRtl,Language,Anchor,Flash,Table,HorizontalRule,Smiley,SpecialChar,PageBreak,Iframe,Format,Font,FontSize,Styles,About,Cut,Copy,Paste,PasteText,PasteFromWord,Form,Checkbox,Radio,TextField,Textarea,Select,Button,ImageButton,HiddenField,ShowBlocks';
+
+  //config.htmlEncodeOutput = false; // html 태그 그대로 보여질 경우
+
+  config.enterMode = CKEDITOR.ENDTER_BR; // <P>태그 제거
+
+  config.allowedContent = true; // html 태그 자동삭제 방지 설정
+
+  config.height = 300;
+};


### PR DESCRIPTION
# Summary

- postContent (프로젝트 소개) 부분에 마크업언어가 따라 붙는 현상을 정규표현식을 이용해 코드수정했습니다.
- 그러나 재 렌더링시에 경로가 길어진 탓인지 console에러가 떠서 옵셔널체이닝을 통해 수정해놓았습니다.

## Component Image 

<img width="944" alt="p 삭제" src="https://user-images.githubusercontent.com/106040138/210740772-7742691c-e9c2-45eb-9959-2223a81ae2e8.png">


## Questions & ETC
- 옵셔널체이닝을 사용하긴 했는데.. 왜 사용해야하는지 아직 명확하게 모르겠습니다. 혹시 잘 아시는 분은 같이 공부해봐요!
