### PR TITLE
feat : post Edit 진행 및 취소 버튼시 뒤로가기 활성화

### DIFF
--- a/src/components/ReadPage/PostComment.js
+++ b/src/components/ReadPage/PostComment.js
@@ -44,6 +44,7 @@ const PostComent = ({ commentData }) => {
         .catch(err => console.log(err));
     }
   };
+
   const keydown = e => {
     if (e.key === "Enter") {
       e.preventDefault();

--- a/src/components/ReadPage/PostEdit.js
+++ b/src/components/ReadPage/PostEdit.js
@@ -19,6 +19,7 @@ const PostEdit = ({ postContents }) => {
       recruitStatus: postContents.recruitStatus,
       groupType: postContents.groupType,
       recruitCapacity: postContents.recruitCapacity,
+      remote: postContents.remote,
       contactType: postContents.contactType,
       contact: postContents.contact,
       startDate: postContents.startDate,
@@ -26,11 +27,11 @@ const PostEdit = ({ postContents }) => {
       designatedStacks: postContents.designatedStacks,
     };
 
-    Axios.patch("http://3.39.32.185:8080/api/post", AxiosData)
-      .then(res => {
-        navigate(`/write`, { state: { postContents } });
-      })
-      .catch(err => console.log("edit patch 실패", err));
+    // Axios.patch("http://3.39.32.185:8080/api/post", AxiosData)
+    //   .then(res => {
+    navigate(`/write`, { state: { AxiosData } });
+    // })
+    // .catch(err => console.log("edit patch 실패", err));
   };
 
   return (

--- a/src/components/ReadPage/PostEdit.js
+++ b/src/components/ReadPage/PostEdit.js
@@ -1,39 +1,37 @@
 import React, { useEffect, useState } from "react";
-import { Axios } from "axios";
+import Axios from "axios";
 import styled from "styled-components";
 import { useParams } from "react-router-dom";
 import { useDispatch } from "react-redux";
 import { BsFillPencilFill } from "react-icons/bs";
 import { AiFillDelete } from "react-icons/ai";
+import { useNavigate } from "react-router-dom";
 
 const PostEdit = ({ postContents }) => {
+  const navigate = useNavigate();
+
   console.log("edit컴포넌트로 Props 받기 성공", postContents);
   const Edit = () => {
-    Axios.patch(
-      "http://3.39.32.185:8080/api/post",
-      {
-        postId: postContents.postId,
-        title: postContents.title,
-        content: postContents.content,
-        recruitStatus: postContents.recruitStatus,
-        groupType: postContents.groupType,
-        recruitCapacity: postContents.recruitCapacity,
-        contactType: postContents.contactType,
-        contact: postContents.contact,
-        startDate: postContents.startDate,
-        expectedTerm: postContents.expectedTerm,
-        designatedStacks: postContents.designatedStacks,
-      }
-      // {
-      //   headers: {
-      //     "Content-Type": "application/json",
-      //   },
-      // }
-    )
+    const AxiosData = {
+      postId: postContents.postId,
+      title: postContents.title,
+      content: postContents.content,
+      recruitStatus: postContents.recruitStatus,
+      groupType: postContents.groupType,
+      recruitCapacity: postContents.recruitCapacity,
+      contactType: postContents.contactType,
+      contact: postContents.contact,
+      startDate: postContents.startDate,
+      expectedTerm: postContents.expectedTerm,
+      designatedStacks: postContents.designatedStacks,
+    };
+
+    Axios.patch("http://3.39.32.185:8080/api/post", AxiosData)
       .then(res => {
         console.log("edit patch 성공", res);
+        navigate(`/write`, { state: { AxiosData } });
       })
-      .catch(err => console.log(err));
+      .catch(err => console.log("edit patch 실패", err));
   };
 
   return (
@@ -41,6 +39,7 @@ const PostEdit = ({ postContents }) => {
       <BsFillPencilFill
         size={18}
         style={{ paddingRight: "15px", cursor: "pointer" }}
+        onClick={Edit}
       />
       <AiFillDelete size={20} style={{ cursor: "pointer" }} />
     </>

--- a/src/components/ReadPage/PostEdit.js
+++ b/src/components/ReadPage/PostEdit.js
@@ -10,7 +10,7 @@ import { useNavigate } from "react-router-dom";
 const PostEdit = ({ postContents }) => {
   const navigate = useNavigate();
 
-  console.log("edit컴포넌트로 Props 받기 성공", postContents);
+  // console.log("edit컴포넌트로 Props 받기 성공", postContents);
   const Edit = () => {
     const AxiosData = {
       postId: postContents.postId,
@@ -28,8 +28,7 @@ const PostEdit = ({ postContents }) => {
 
     Axios.patch("http://3.39.32.185:8080/api/post", AxiosData)
       .then(res => {
-        console.log("edit patch 성공", res);
-        navigate(`/write`, { state: { AxiosData } });
+        navigate(`/write`, { state: { postContents } });
       })
       .catch(err => console.log("edit patch 실패", err));
   };

--- a/src/pages/WritePage.js
+++ b/src/pages/WritePage.js
@@ -112,10 +112,6 @@ const WritePage = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  //Data 받아오기
-  const postContents = location.state;
-  console.log(postContents);
-
   const stackHandler = event => {
     const {
       target: { value },
@@ -174,6 +170,33 @@ const WritePage = () => {
     // Define your onSubmit function here
     // ...
     // for example, setData() here
+  };
+
+  //Data 받아오기
+  const AxiosData = location.state;
+
+  const EditPost = e => {
+    const EditData = {
+      postId: AxiosData.AxiosData.postId,
+      title: AxiosData.AxiosData.title,
+      content: AxiosData.AxiosData.content,
+      recruitStatus: AxiosData.AxiosData.recruitStatus,
+      groupType: AxiosData.AxiosData.groupType,
+      recruitCapacity: AxiosData.AxiosData.recruitCapacity,
+      remote: AxiosData.AxiosData.remote,
+      contactType: AxiosData.AxiosData.contactType,
+      contact: AxiosData.AxiosData.contact,
+      startDate: AxiosData.AxiosData.startDate,
+      expectedTerm: AxiosData.AxiosData.expectedTerm,
+      designatedStacks: AxiosData.AxiosData.designatedStacks,
+    };
+    e.preventDefault();
+
+    Axios.patch("http://3.39.32.185:8080/api/post", EditData)
+      .then(res => {
+        navigate("/post/" + res.data.data.postId);
+      })
+      .catch(err => console.log("edit patch 실패", err));
   };
 
   const addPost = e => {
@@ -236,9 +259,7 @@ const WritePage = () => {
             >
               <InputLabel>모집구분</InputLabel>
               <Select
-                value={
-                  postContents ? postContents.postContents.groupType : groupType
-                }
+                value={AxiosData ? AxiosData.AxiosData.groupType : groupType}
                 label="setForm"
                 onChange={group_type_Handler}
               >
@@ -256,8 +277,8 @@ const WritePage = () => {
               <InputLabel>모집인원</InputLabel>
               <Select
                 value={
-                  postContents
-                    ? postContents.postContents.recruitCapacity
+                  AxiosData
+                    ? AxiosData.AxiosData.recruitCapacity
                     : recruitCapacity
                 }
                 label="form"
@@ -285,7 +306,7 @@ const WritePage = () => {
             >
               <InputLabel>진행방식</InputLabel>
               <Select
-                value={postContents ? postContents.postContents.remote : remote}
+                value={AxiosData ? AxiosData.AxiosData.remote : remote}
                 label="form_how"
                 onChange={remoteHandler}
               >
@@ -303,9 +324,7 @@ const WritePage = () => {
               <InputLabel>진행기간</InputLabel>
               <Select
                 value={
-                  postContents
-                    ? postContents.postContents.expectedTerm
-                    : expectedTerm
+                  AxiosData ? AxiosData.AxiosData.expectedTerm : expectedTerm
                 }
                 label="form_term"
                 onChange={termHandler}
@@ -333,8 +352,8 @@ const WritePage = () => {
                 id="demo-multiple-name"
                 multiple
                 value={
-                  postContents
-                    ? postContents.postContents.designatedStacks
+                  AxiosData
+                    ? AxiosData.AxiosData.designatedStacks
                     : designatedStacks
                 }
                 onChange={stackHandler}
@@ -372,11 +391,7 @@ const WritePage = () => {
               <LocalizationProvider dateAdapter={AdapterDayjs}>
                 <DatePicker
                   label="시작예정일"
-                  value={
-                    postContents
-                      ? postContents.postContents.startDate
-                      : startDate
-                  }
+                  value={AxiosData ? AxiosData.AxiosData.startDate : startDate}
                   onChange={date_Hanler}
                   renderInput={params => <TextField {...params} />}
                 />
@@ -398,9 +413,7 @@ const WritePage = () => {
               <InputLabel>연락 방법</InputLabel>
               <Select
                 value={
-                  postContents
-                    ? postContents.postContents.contactType
-                    : contactType
+                  AxiosData ? AxiosData.AxiosData.contactType : contactType
                 }
                 label="form_how"
                 onChange={contact_typeHandler}
@@ -425,9 +438,7 @@ const WritePage = () => {
 
               <TextField
                 id="standard-basic"
-                value={
-                  postContents ? postContents.postContents.contact : contact
-                }
+                value={AxiosData ? AxiosData.AxiosData.contact : contact}
                 onChange={contact_Handler}
                 label="연락 주소"
                 variant="outlined"
@@ -440,7 +451,6 @@ const WritePage = () => {
           </Box>
         </Grid>
         <Grid item xs={1}></Grid>
-
         <Grid item xs={1}></Grid>
         <Grid item xs={10}>
           <Title>
@@ -453,7 +463,7 @@ const WritePage = () => {
           </label>
           <TextField
             required
-            value={postContents ? postContents.postContents.title : title}
+            value={AxiosData ? AxiosData.AxiosData.title : title}
             onChange={title_Hanler}
             placeholder="글 제목을 입력해주세요"
             variant="outlined"
@@ -463,7 +473,7 @@ const WritePage = () => {
           <WriteArea>
             <CKEditor
               editor={ClassicEditor}
-              data={postContents ? postContents.postContents.content : content}
+              data={AxiosData ? AxiosData.AxiosData.content : content}
               onReady={editor => {
                 // You can store the "editor" and use when it is needed.
                 console.log("Editor is ready to use!", editor);
@@ -489,7 +499,6 @@ const WritePage = () => {
           </WriteArea>
         </Grid>
         <Grid item xs={1}></Grid>
-
         <Grid
           item
           // xs={12}
@@ -499,9 +508,9 @@ const WritePage = () => {
           justifyContent="flex-end"
         >
           <div style={{ padding: "50px 0" }}>
-            {postContents ? (
+            {AxiosData ? (
               <button
-                onClick={addPost}
+                onClick={EditPost}
                 className="buttonComplete"
                 name="register"
                 style={{ marginRight: "10px" }}

--- a/src/pages/WritePage.js
+++ b/src/pages/WritePage.js
@@ -16,7 +16,7 @@ import OutlinedInput from "@mui/material/OutlinedInput";
 import Chip from "@mui/material/Chip";
 import Axios from "axios";
 import TextField from "@mui/material/TextField";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { DatePicker } from "@mui/x-date-pickers/DatePicker";
@@ -98,7 +98,7 @@ const Circle = styled.div`
 
 const WritePage = () => {
   const [title, setTitle] = useState("");
-  const [recruitCapacity, setCapacity] = useState(""); //모집인원
+  const [recruitCapacity, setRecruitCapacity] = useState(""); //모집인원
   const [remote, setRemote] = useState(""); //진행방식
   const [expectedTerm, setTerm] = useState(""); //진행기간
   const [startDate, setStartDate] = React.useState(null);
@@ -110,6 +110,11 @@ const WritePage = () => {
   const theme = useTheme();
   const [designatedStacks, setStack] = React.useState([]);
   const navigate = useNavigate();
+  const location = useLocation();
+
+  //Data 받아오기
+  const AxiosData = location.state;
+  console.log(AxiosData);
 
   const stackHandler = event => {
     const {
@@ -121,8 +126,9 @@ const WritePage = () => {
     );
   };
 
+  // 모집 인원
   const capacityHandler = e => {
-    setCapacity(e.target.value);
+    setRecruitCapacity(e.target.value);
     console.log(e.target.value);
   };
 
@@ -149,6 +155,7 @@ const WritePage = () => {
   const group_type_Handler = e => {
     setGroupType(e.target.value);
     console.log(e.target.value);
+    // console.log(AxiosData);
   };
 
   const date_Hanler = newValue => {
@@ -185,7 +192,6 @@ const WritePage = () => {
         recruitCapacity,
         designatedStacks,
         remote,
-
         // recruit_status,
         // recruit_capacity,
         // type,
@@ -195,7 +201,7 @@ const WritePage = () => {
       },
       {
         headers: {
-          //       "Access-Control-Allow-Origin": "*",
+          //"Access-Control-Allow-Origin": "*",
           "Content-Type": "application/json",
         },
       }
@@ -207,30 +213,9 @@ const WritePage = () => {
       .catch(err => console.log(err));
   };
 
-  // console.log("글등록");
-  // console.log({
-  //   recruit_status,
-  //   recruit_capacity,
-  //   type,
-  //   expected_term,
-  //   stack,
-  //   startDate,
-  // });
-
   const back = e => {
-    console.log("취소");
+    navigate(-1);
   };
-
-  // useEffect(() => {
-  //   console.log({
-  //     recruit_status,
-  //     recruit_capacity,
-  //     type,
-  //     expected_term,
-  //     stacklist,
-  //     startDate,
-  //   });
-  // });
 
   return (
     <>
@@ -251,7 +236,7 @@ const WritePage = () => {
             >
               <InputLabel>모집구분</InputLabel>
               <Select
-                value={groupType}
+                value={AxiosData ? AxiosData.AxiosData.groupType : groupType}
                 label="setForm"
                 onChange={group_type_Handler}
               >
@@ -268,7 +253,11 @@ const WritePage = () => {
             >
               <InputLabel>모집인원</InputLabel>
               <Select
-                value={recruitCapacity}
+                value={
+                  AxiosData
+                    ? AxiosData.AxiosData.recruitCapacity
+                    : recruitCapacity
+                }
                 label="form"
                 onChange={capacityHandler}
               >
@@ -307,7 +296,9 @@ const WritePage = () => {
             >
               <InputLabel>진행기간</InputLabel>
               <Select
-                value={expectedTerm}
+                value={
+                  AxiosData ? AxiosData.AxiosData.expectedTerm : expectedTerm
+                }
                 label="form_term"
                 onChange={termHandler}
               >
@@ -333,7 +324,11 @@ const WritePage = () => {
                 labelId="demo-multiple-name-label"
                 id="demo-multiple-name"
                 multiple
-                value={designatedStacks}
+                value={
+                  AxiosData
+                    ? AxiosData.AxiosData.designatedStacks
+                    : designatedStacks
+                }
                 onChange={stackHandler}
                 input={<OutlinedInput label="Name" />}
                 renderValue={selected => (
@@ -369,7 +364,7 @@ const WritePage = () => {
               <LocalizationProvider dateAdapter={AdapterDayjs}>
                 <DatePicker
                   label="시작예정일"
-                  value={startDate}
+                  value={AxiosData ? AxiosData.AxiosData.startDate : startDate}
                   onChange={date_Hanler}
                   renderInput={params => <TextField {...params} />}
                 />
@@ -390,7 +385,9 @@ const WritePage = () => {
             >
               <InputLabel>연락 방법</InputLabel>
               <Select
-                value={contactType}
+                value={
+                  AxiosData ? AxiosData.AxiosData.contactType : contactType
+                }
                 label="form_how"
                 onChange={contact_typeHandler}
                 style={{
@@ -414,7 +411,7 @@ const WritePage = () => {
 
               <TextField
                 id="standard-basic"
-                value={contact}
+                value={AxiosData ? AxiosData.AxiosData.contact : contact}
                 onChange={contact_Handler}
                 label="연락 주소"
                 variant="outlined"
@@ -440,7 +437,7 @@ const WritePage = () => {
           </label>
           <TextField
             required
-            value={title}
+            value={AxiosData ? AxiosData.AxiosData.title : title}
             onChange={title_Hanler}
             placeholder="글 제목을 입력해주세요"
             variant="outlined"
@@ -450,7 +447,7 @@ const WritePage = () => {
           <WriteArea>
             <CKEditor
               editor={ClassicEditor}
-              data={content}
+              data={AxiosData ? AxiosData.AxiosData.content : content}
               onReady={editor => {
                 // You can store the "editor" and use when it is needed.
                 console.log("Editor is ready to use!", editor);
@@ -486,14 +483,25 @@ const WritePage = () => {
           justifyContent="flex-end"
         >
           <div style={{ padding: "50px 0" }}>
-            <button
-              onClick={addPost}
-              className="buttonComplete"
-              name="register"
-              style={{ marginRight: "10px" }}
-            >
-              글 등록
-            </button>
+            {AxiosData ? (
+              <button
+                onClick={addPost}
+                className="buttonComplete"
+                name="register"
+                style={{ marginRight: "10px" }}
+              >
+                게시글 수정
+              </button>
+            ) : (
+              <button
+                onClick={addPost}
+                className="buttonComplete"
+                name="register"
+                style={{ marginRight: "10px" }}
+              >
+                글 등록
+              </button>
+            )}
             <button
               style={{
                 border: "none",

--- a/src/pages/WritePage.js
+++ b/src/pages/WritePage.js
@@ -113,8 +113,8 @@ const WritePage = () => {
   const location = useLocation();
 
   //Data 받아오기
-  const AxiosData = location.state;
-  console.log(AxiosData);
+  const postContents = location.state;
+  console.log(postContents);
 
   const stackHandler = event => {
     const {
@@ -155,7 +155,7 @@ const WritePage = () => {
   const group_type_Handler = e => {
     setGroupType(e.target.value);
     console.log(e.target.value);
-    // console.log(AxiosData);
+    // console.log(postContents);
   };
 
   const date_Hanler = newValue => {
@@ -236,7 +236,9 @@ const WritePage = () => {
             >
               <InputLabel>모집구분</InputLabel>
               <Select
-                value={AxiosData ? AxiosData.AxiosData.groupType : groupType}
+                value={
+                  postContents ? postContents.postContents.groupType : groupType
+                }
                 label="setForm"
                 onChange={group_type_Handler}
               >
@@ -254,8 +256,8 @@ const WritePage = () => {
               <InputLabel>모집인원</InputLabel>
               <Select
                 value={
-                  AxiosData
-                    ? AxiosData.AxiosData.recruitCapacity
+                  postContents
+                    ? postContents.postContents.recruitCapacity
                     : recruitCapacity
                 }
                 label="form"
@@ -282,7 +284,11 @@ const WritePage = () => {
               }}
             >
               <InputLabel>진행방식</InputLabel>
-              <Select value={remote} label="form_how" onChange={remoteHandler}>
+              <Select
+                value={postContents ? postContents.postContents.remote : remote}
+                label="form_how"
+                onChange={remoteHandler}
+              >
                 <MenuItem value={true}>온라인</MenuItem>
                 <MenuItem value={false}>오프라인</MenuItem>
               </Select>
@@ -297,7 +303,9 @@ const WritePage = () => {
               <InputLabel>진행기간</InputLabel>
               <Select
                 value={
-                  AxiosData ? AxiosData.AxiosData.expectedTerm : expectedTerm
+                  postContents
+                    ? postContents.postContents.expectedTerm
+                    : expectedTerm
                 }
                 label="form_term"
                 onChange={termHandler}
@@ -325,8 +333,8 @@ const WritePage = () => {
                 id="demo-multiple-name"
                 multiple
                 value={
-                  AxiosData
-                    ? AxiosData.AxiosData.designatedStacks
+                  postContents
+                    ? postContents.postContents.designatedStacks
                     : designatedStacks
                 }
                 onChange={stackHandler}
@@ -364,7 +372,11 @@ const WritePage = () => {
               <LocalizationProvider dateAdapter={AdapterDayjs}>
                 <DatePicker
                   label="시작예정일"
-                  value={AxiosData ? AxiosData.AxiosData.startDate : startDate}
+                  value={
+                    postContents
+                      ? postContents.postContents.startDate
+                      : startDate
+                  }
                   onChange={date_Hanler}
                   renderInput={params => <TextField {...params} />}
                 />
@@ -386,7 +398,9 @@ const WritePage = () => {
               <InputLabel>연락 방법</InputLabel>
               <Select
                 value={
-                  AxiosData ? AxiosData.AxiosData.contactType : contactType
+                  postContents
+                    ? postContents.postContents.contactType
+                    : contactType
                 }
                 label="form_how"
                 onChange={contact_typeHandler}
@@ -411,7 +425,9 @@ const WritePage = () => {
 
               <TextField
                 id="standard-basic"
-                value={AxiosData ? AxiosData.AxiosData.contact : contact}
+                value={
+                  postContents ? postContents.postContents.contact : contact
+                }
                 onChange={contact_Handler}
                 label="연락 주소"
                 variant="outlined"
@@ -437,7 +453,7 @@ const WritePage = () => {
           </label>
           <TextField
             required
-            value={AxiosData ? AxiosData.AxiosData.title : title}
+            value={postContents ? postContents.postContents.title : title}
             onChange={title_Hanler}
             placeholder="글 제목을 입력해주세요"
             variant="outlined"
@@ -447,7 +463,7 @@ const WritePage = () => {
           <WriteArea>
             <CKEditor
               editor={ClassicEditor}
-              data={AxiosData ? AxiosData.AxiosData.content : content}
+              data={postContents ? postContents.postContents.content : content}
               onReady={editor => {
                 // You can store the "editor" and use when it is needed.
                 console.log("Editor is ready to use!", editor);
@@ -483,7 +499,7 @@ const WritePage = () => {
           justifyContent="flex-end"
         >
           <div style={{ padding: "50px 0" }}>
-            {AxiosData ? (
+            {postContents ? (
               <button
                 onClick={addPost}
                 className="buttonComplete"


### PR DESCRIPTION
# Summary

post Edit 진행 및 취소 버튼시 뒤로가기 활성화

## Component Image 

### Edit(수정하기) 클릭시 데이터 받아오기

![edit](https://user-images.githubusercontent.com/100752008/213437602-74da1998-8c76-4d60-814b-3bd0388e74f7.gif)

### Back 버튼 활성화

![back](https://user-images.githubusercontent.com/100752008/213437566-da30927c-d24a-46b3-9cc8-70d6714bce25.gif)

# Details

### Edit 진행중
- 데이터를 받아오는데 '진행 방식' 부분이 불리언값으로 적용되는데 Api patch data에는 담겨있지 않는거 같더라구요(remote 부분)
일단 나머지 부분은 다 데이터를 받아 와서 자동으로 적용 되게끔 바꿨습니다 (백이랑 한번 얘기가 필요할 듯)

- 데이터는 받아왔고, 관리자 권한으로 데이터를 수정을 할 수 있게끔 해야하는데 그 기능 구현을 어떻게 할지 생각해볼게요!
(수정 완료 버튼 기능도 활성화 해야 함 - axios 요청을 어떻게 해야 하나.. 고민해야함)

#### Back  

취소 버튼 누르면 뒤로가기 구현

# Issues
1. 기술 스텍 데이터가 쌓임 현상이 일어납니다.. 안건드렸는데 왜이러는지 ㅜㅜ 확인 필요함..